### PR TITLE
remove deprecated spdy_headers_comp option from nginx-ssl.conf

### DIFF
--- a/conf/nginx-ssl.conf
+++ b/conf/nginx-ssl.conf
@@ -46,12 +46,6 @@ ssl_session_timeout 1d;
 # nginx 1.5.9+ ONLY
 #ssl_buffer_size 1400; 
 
-# SPDY header compression (0 for none, 9 for slow/heavy compression). Preferred is 6. 
-# 
-# BUT: header compression is flawed and vulnerable in SPDY versions 1 - 3.
-# Disable with 0, until using a version of nginx with SPDY 4.
-spdy_headers_comp 0;
-
 # Now let's really get fancy, and pre-generate a 2048 bit random parameter
 # for DH elliptic curves. If not created and specified, default is only 1024 bits. 
 #


### PR DESCRIPTION
With the move from ubuntu 14.04 to 16.04 the updated nginx version moved from spdy to http2 module so this option is deprecated now.

Check with `nginx -t` before and after the PR.